### PR TITLE
feat: post login handler page

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -50,7 +50,9 @@ export default async function Page() {
           <form
             onSubmit={async () => {
               'use server';
-              await signIn('github');
+              await signIn('github', {
+                redirectTo: '/login/success',
+              });
             }}
           >
             <Button size={'default'} className="w-full">

--- a/src/app/(auth)/login/success/login-redirect.tsx
+++ b/src/app/(auth)/login/success/login-redirect.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import GitloomIcon from '@/components/icons/gitloom';
+import { AnimatedCircularProgressBar } from '@/components/magicui/animated-circular-progress-bar';
+import { LAST_USED_REPO_LOCAL_STORAGE_KEY } from '@/constants';
+import { cn, waitFor } from '@/lib/utils';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+interface Task {
+  pending: boolean;
+  text: string;
+}
+
+export default function LoginRedirect() {
+  const router = useRouter();
+
+  const [value, setValue] = useState(0);
+  const [tasks, setTasks] = useState<Task[]>([
+    {
+      pending: true,
+      text: 'Logging you in...',
+    },
+  ]);
+
+  function completeAllTasks(): void {
+    setTasks((prev) => prev.map((t) => ({ ...t, pending: false })));
+  }
+
+  function addTask(task: Task): void {
+    completeAllTasks();
+    setTasks((prev) => [...prev, task]);
+  }
+
+  useEffect(() => {
+    (async () => {
+      // task: no.1
+      await waitFor(500);
+      setValue((prev) => prev + 100 / 3);
+      // task: no.2
+      addTask({ pending: true, text: 'Looking for your last used repo...' });
+      const lastUsedRepo = localStorage.getItem(LAST_USED_REPO_LOCAL_STORAGE_KEY);
+      await waitFor(1500);
+      setValue((prev) => prev + 100 / 3);
+      // task: no.2
+      addTask({ pending: true, text: 'Redirecting...' });
+      await waitFor(1500);
+      if (lastUsedRepo !== null) {
+        // window.location.href = `/@${lastUsedRepo}`;
+        router.push(`/@${lastUsedRepo}`);
+      } else {
+        // window.location.href = '/new';
+        router.push(`/new`);
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4">
+      <div className="relative grid place-items-center">
+        <AnimatedCircularProgressBar
+          max={100}
+          min={0}
+          value={value}
+          gaugePrimaryColor="var(--color-muted-foreground)"
+          gaugeSecondaryColor="var(--color-muted)"
+          className="size-30 stroke-1 [&>span[data-current-value]]:hidden"
+        />
+        <GitloomIcon className="absolute size-10" />
+      </div>
+      <div className="relative text-sm [&>span]:whitespace-nowrap">
+        {tasks.map((task, idx) => (
+          <span
+            key={idx}
+            className={cn(
+              task.pending ? 'text-foreground' : 'text-muted-foreground',
+              'animate-in fade-in slide-in-from-bottom-75 absolute left-1/2 -translate-x-1/2 transform font-medium duration-500',
+            )}
+            style={{ top: `${idx * 1.5}rem` }}
+          >
+            {task.text}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/success/page.tsx
+++ b/src/app/(auth)/login/success/page.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from 'next';
+import LoginRedirect from './login-redirect';
+
+export const metadata: Metadata = {
+  title: 'Setting up...',
+};
+
+export default function Page() {
+  return <LoginRedirect />;
+}

--- a/src/components/magicui/animated-circular-progress-bar.tsx
+++ b/src/components/magicui/animated-circular-progress-bar.tsx
@@ -1,0 +1,101 @@
+import { cn } from '@/lib/utils';
+
+interface AnimatedCircularProgressBarProps {
+  max: number;
+  value: number;
+  min: number;
+  gaugePrimaryColor: string;
+  gaugeSecondaryColor: string;
+  className?: string;
+}
+
+export function AnimatedCircularProgressBar({
+  max = 100,
+  min = 0,
+  value = 0,
+  gaugePrimaryColor,
+  gaugeSecondaryColor,
+  className,
+}: AnimatedCircularProgressBarProps) {
+  const circumference = 2 * Math.PI * 45;
+  const percentPx = circumference / 100;
+  const currentPercent = Math.round(((value - min) / (max - min)) * 100);
+
+  return (
+    <div
+      className={cn('relative size-40 text-2xl font-semibold', className)}
+      style={
+        {
+          '--circle-size': '100px',
+          '--circumference': circumference,
+          '--percent-to-px': `${percentPx}px`,
+          '--gap-percent': '5',
+          '--offset-factor': '0',
+          '--transition-length': '1s',
+          '--transition-step': '200ms',
+          '--delay': '0s',
+          '--percent-to-deg': '3.6deg',
+          transform: 'translateZ(0)',
+        } as React.CSSProperties
+      }
+    >
+      <svg fill="none" className="size-full" strokeWidth="2" viewBox="0 0 100 100">
+        {currentPercent <= 90 && currentPercent >= 0 && (
+          <circle
+            cx="50"
+            cy="50"
+            r="45"
+            strokeWidth="5"
+            strokeDashoffset="0"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="opacity-100"
+            style={
+              {
+                stroke: gaugeSecondaryColor,
+                '--stroke-percent': 90 - currentPercent,
+                '--offset-factor-secondary': 'calc(1 - var(--offset-factor))',
+                strokeDasharray:
+                  'calc(var(--stroke-percent) * var(--percent-to-px)) var(--circumference)',
+                transform:
+                  'rotate(calc(1turn - 90deg - (var(--gap-percent) * var(--percent-to-deg) * var(--offset-factor-secondary)))) scaleY(-1)',
+                transition: 'all var(--transition-length) ease var(--delay)',
+                transformOrigin: 'calc(var(--circle-size) / 2) calc(var(--circle-size) / 2)',
+              } as React.CSSProperties
+            }
+          />
+        )}
+        <circle
+          cx="50"
+          cy="50"
+          r="45"
+          strokeWidth="5"
+          strokeDashoffset="0"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="opacity-100"
+          style={
+            {
+              stroke: gaugePrimaryColor,
+              '--stroke-percent': currentPercent,
+              strokeDasharray:
+                'calc(var(--stroke-percent) * var(--percent-to-px)) var(--circumference)',
+              transition:
+                'var(--transition-length) ease var(--delay),stroke var(--transition-length) ease var(--delay)',
+              transitionProperty: 'stroke-dasharray,transform',
+              transform:
+                'rotate(calc(-90deg + var(--gap-percent) * var(--offset-factor) * var(--percent-to-deg)))',
+              transformOrigin: 'calc(var(--circle-size) / 2) calc(var(--circle-size) / 2)',
+            } as React.CSSProperties
+          }
+        />
+      </svg>
+      <span
+        data-current-value={currentPercent}
+        className="animate-in fade-in absolute inset-0 m-auto size-fit delay-[var(--delay)] duration-[var(--transition-length)] ease-linear"
+      >
+        {currentPercent}
+      </span>
+    </div>
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const LAST_USED_REPO_LOCAL_STORAGE_KEY = 'last-used-repo';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,10 +7,13 @@ export function cn(...inputs: ClassValue[]) {
 
 /**
  * Generate Metatdata title with " – Gitloom" affix.
- *
  * @param title - String to add affix.
  * @returns
  */
 export function generateMetadataTitleFor(title: string) {
   return `${title} – Gitloom`;
+}
+
+export async function waitFor(t: number) {
+  return new Promise((resolve) => setTimeout(resolve, t));
 }


### PR DESCRIPTION
After successful login, user gets redirected to `/login/success`.
A client page, where gets the last used repo information and set things up...