### PR TITLE
fix(login): add explicit type="submit" to form button

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -55,7 +55,7 @@ export default async function Page() {
               });
             }}
           >
-            <Button size={'default'} className="w-full">
+            <Button type='submit' size={'default'} className="w-full">
               <GithubIcon className="size-5" />
               Sign in with Github
             </Button>


### PR DESCRIPTION
Buttons normally have `type="submit"` by default, but in some browsers, this doesn't seem to work as expected.
Explicitly adding `submit` type to prevent this unexpected behaviours.

Fixes #15 