### PR TITLE
fix: quote glob based script commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "lint:strict": "next lint '*/**/*.{js,jsx,ts,tsx}'",
-    "format": "prettier --write */**/*.{js,jsx,json,ts,tsx,scss,css,md}",
+    "lint:strict": "next lint \"*/**/*.{js,jsx,ts,tsx}\"",
+    "format": "prettier --write \"**/*.{js,jsx,json,ts,tsx,css,md}\"",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "pre-commit": "lint-staged"


### PR DESCRIPTION
Fix shell expansion issue by using quotes around glob pattern.
without this, shell fails if there is no file pattern in code base, so does prettier.