### PR TITLE
feat: perform checks and import repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "lucide-react": "^0.513.0",
     "next": "15.3.3",
     "next-auth": "5.0.0-beta.28",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-select": "^2.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -429,6 +432,19 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/react-alert-dialog@1.1.14':
+    resolution: {integrity: sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -484,6 +500,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.14':
+    resolution: {integrity: sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -2817,6 +2846,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/react-alert-dialog@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.7)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.7
+      '@types/react-dom': 19.1.6(@types/react@19.1.7)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2862,6 +2905,28 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.7
+
+  '@radix-ui/react-dialog@1.1.14(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.7)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.7)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.7)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.7
+      '@types/react-dom': 19.1.6(@types/react@19.1.7)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.7)(react@19.1.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,18 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.28
         version: 5.0.0-beta.28(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      sonner:
+        specifier: ^2.0.5
+        version: 2.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1942,6 +1948,12 @@ packages:
       nodemailer:
         optional: true
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@15.3.3:
     resolution: {integrity: sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -2311,6 +2323,12 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  sonner@2.0.5:
+    resolution: {integrity: sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4417,6 +4435,11 @@ snapshots:
       next: 15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.3
@@ -4787,6 +4810,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  sonner@2.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/(app)/[repo]/_components/create-config-alert-dialog.tsx
+++ b/src/app/(app)/[repo]/_components/create-config-alert-dialog.tsx
@@ -1,0 +1,58 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useSession } from 'next-auth/react';
+import { Dispatch, SetStateAction } from 'react';
+
+interface Props {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export default function CreateConfigAlertDialog({ open, setOpen }: Props) {
+  const { data: session } = useSession();
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Configuration File Required</AlertDialogTitle>
+          <AlertDialogDescription>
+            We noticed your repository doesn&apos;t have a{' '}
+            <code className="font-mono text-sm">.gitloom/config.json</code> file. This file helps
+            Gitloom understand your project structure and workflows.
+          </AlertDialogDescription>
+          <div className="bg-secondary/25 mt-2 flex gap-4 rounded-md border p-4">
+            <Avatar className="size-6">
+              <AvatarImage src={session?.user?.image ?? undefined} />
+              <AvatarFallback>{session?.user?.name?.[0] ?? 'U'}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1">
+              <p className="text-sm font-medium">Auto-generated configuration</p>
+              <p className="text-muted-foreground text-sm">Will create default config with:</p>
+              <ul className="text-muted-foreground mt-1 ml-4 list-disc text-sm">
+                <li>Latest version</li>
+                <li>Contents and its locations</li>
+              </ul>
+            </div>
+            <span className="text-muted-foreground text-xs">Just now</span>
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="gap-4">
+          <AlertDialogCancel onClick={() => setOpen(false)}>Cancel</AlertDialogCancel>
+          <AlertDialogAction className="bg-primary hover:bg-primary/90">
+            Create Config
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/(app)/[repo]/_components/loading-repo.tsx
+++ b/src/app/(app)/[repo]/_components/loading-repo.tsx
@@ -64,6 +64,20 @@ export default function LoadingRepo({ repo }: { repo: string }) {
     })();
   }, [session, repo, failCheck]);
 
+  // return icon for each status state
+  function getIcon(status: CheckStatus) {
+    switch (status) {
+      case 'checking':
+        return <Loader2 className="size-5 animate-spin" />;
+      case 'resolved':
+        return <CircleCheck className="size-5" />;
+      case 'failed':
+        return <CircleX className="text-destructive size-5" />;
+      default:
+        return <Loader2 className="size-5" />;
+    }
+  }
+
   return (
     <div className="grid h-full place-items-center">
       <div className="flex min-w-75 flex-col gap-2 p-4">
@@ -79,19 +93,14 @@ export default function LoadingRepo({ repo }: { repo: string }) {
           <div
             key={idx}
             className={cn(
-              'flex items-center gap-2 rounded-md border p-2',
-              ['pending', 'resolved'].includes(check.status) && 'text-muted-foreground',
+              'flex items-center gap-2 rounded-md border p-2 transition-colors',
+              (check.status === 'pending' || check.status === 'resolved') &&
+                'text-muted-foreground',
+              check.status === 'checking' && 'bg-secondary/50',
+              check.status === 'failed' && 'bg-destructive/10',
             )}
           >
-            {check.status === 'checking' ? (
-              <Loader2 className="size-5 animate-spin" />
-            ) : check.status === 'resolved' ? (
-              <CircleCheck className="size-5" />
-            ) : check.status === 'failed' ? (
-              <CircleX className="text-destructive size-5" />
-            ) : (
-              <Loader2 className="size-5" />
-            )}
+            {getIcon(check.status)}
             <span
               className={cn(
                 'text-sm font-medium transition-colors',

--- a/src/app/(app)/[repo]/_components/loading-repo.tsx
+++ b/src/app/(app)/[repo]/_components/loading-repo.tsx
@@ -1,0 +1,97 @@
+import GithubIcon from '@/components/icons/github';
+import GitloomIcon from '@/components/icons/gitloom';
+import { cn } from '@/lib/utils';
+import { CircleCheck, CircleX, Loader2, X } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+
+type CheckStatus = 'pending' | 'checking' | 'resolved' | 'failed';
+type CheckIds = 'repo-status' | 'config-file' | 'contents';
+
+interface CheckItem {
+  id: CheckIds;
+  text: string;
+  status: CheckStatus;
+}
+
+export default function LoadingRepo({ repo }: { repo: string }) {
+  const { data: session } = useSession();
+  const [checks, setChecks] = useState<CheckItem[]>([
+    { id: 'repo-status', text: 'Checking repo status', status: 'checking' },
+    { id: 'config-file', text: 'Looking for configuration file', status: 'pending' },
+    { id: 'contents', text: 'Loading contents', status: 'pending' },
+  ]);
+
+  useEffect(() => {
+    if (!session) return;
+    // remove @ prefix
+    const repoName = repo.slice(1);
+    (async () => {
+      // no.1: check repo
+      await fetch(`https://api.github.com/repos/${session?.user?.username}/${repoName}s`).then(
+        (res) => {
+          if (res.ok) {
+            setChecks((prev) =>
+              prev.map((check) =>
+                check.id === 'repo-status'
+                  ? { ...check, status: 'resolved' }
+                  : check.id === 'config-file'
+                    ? { ...check, status: 'checking' }
+                    : check,
+              ),
+            );
+          } else {
+            // repo not found
+            setChecks((prev) =>
+              prev.map((check) =>
+                check.id === 'repo-status' ? { ...check, status: 'failed' } : check,
+              ),
+            );
+          }
+        },
+      );
+    })();
+  }, [session, repo]);
+
+  return (
+    <div className="grid h-full place-items-center">
+      <div className="flex min-w-75 flex-col gap-2 p-4">
+        <div className="mx-auto mb-2 flex flex-col items-center gap-2">
+          <div className="flex items-center gap-2">
+            <GitloomIcon className="size-5" />
+            <X className="text-muted-foreground size-5 stroke-1 text-xs" />
+            <GithubIcon className="fill-foreground size-5" />
+          </div>
+          <h2 className="text-xl font-bold">{repo}</h2>
+        </div>
+        {checks.map((check, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              'flex items-center gap-2 rounded-md border p-2',
+              ['pending', 'resolved'].includes(check.status) && 'text-muted-foreground',
+            )}
+          >
+            {check.status === 'checking' ? (
+              <Loader2 className="size-5 animate-spin" />
+            ) : check.status === 'resolved' ? (
+              <CircleCheck className="size-5" />
+            ) : check.status === 'failed' ? (
+              <CircleX className="text-destructive size-5" />
+            ) : (
+              <Loader2 className="size-5" />
+            )}
+            <span
+              className={cn(
+                'text-sm font-medium transition-colors',
+                check.status === 'failed' && 'text-destructive',
+              )}
+            >
+              {check.text}...
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[repo]/_components/loading-repo.tsx
+++ b/src/app/(app)/[repo]/_components/loading-repo.tsx
@@ -21,7 +21,8 @@ export default function LoadingRepo({ repo }: { repo: string }) {
   const { data: session } = useSession();
   // session gets synced everytime
   // which re-triggers all checks
-  const stableSession = useMemo(() => session, [session?.accessToken, session?.user?.username]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableSession = useMemo(() => session, [session?.accessToken]);
 
   const [openCreateConfigAlertDialog, setOpenCreateConfigAlertDialog] = useState(false);
   const [checks, setChecks] = useState<CheckItem[]>([
@@ -126,6 +127,7 @@ export default function LoadingRepo({ repo }: { repo: string }) {
       <CreateConfigAlertDialog
         open={openCreateConfigAlertDialog}
         setOpen={setOpenCreateConfigAlertDialog}
+        repo={repo.slice(1)}
       />
       {/* rest of the layout */}
       <div className="flex min-w-75 flex-col gap-2 p-4">

--- a/src/app/(app)/[repo]/_components/loading-repo.tsx
+++ b/src/app/(app)/[repo]/_components/loading-repo.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { CircleCheck, CircleX, Loader2, X } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 type CheckStatus = 'pending' | 'checking' | 'resolved' | 'failed';
 type CheckIds = 'repo-status' | 'config-file' | 'contents';
@@ -43,11 +44,23 @@ export default function LoadingRepo({ repo }: { repo: string }) {
       await checkRepo({
         accessToken: session.accessToken,
         username: session.user?.username,
-        repo: repoName,
+        repo: repoName + 'x',
       }).then((ok) => {
-        console.log(ok);
         if (!ok) {
+          const toastId = 'repo-status-failed-toast';
           failCheck('repo-status');
+          if (!toast.getToasts().some((t) => t.id === toastId)) {
+            toast.error('OhNo! Repo not accessible', {
+              id: toastId,
+              description: `Repo doesn't exist or you don't have permission.`,
+              action: {
+                label: 'Retry',
+                onClick: () => window.location.reload(),
+              },
+              position: 'bottom-center',
+              duration: 8000,
+            });
+          }
           return;
         }
 

--- a/src/app/(app)/[repo]/_components/recent-actions.tsx
+++ b/src/app/(app)/[repo]/_components/recent-actions.tsx
@@ -1,0 +1,16 @@
+import { NavigationOff } from 'lucide-react';
+
+export default function RecentActions() {
+  return (
+    <div className="col-span-1">
+      <h5 className="text-muted-foreground text-sm font-medium">Recent Actions</h5>
+      <div className="flex flex-col items-center justify-center gap-4 py-10">
+        <NavigationOff className="text-muted-foreground size-10 stroke-1" />
+        <div className="flex flex-col items-center">
+          <span className="text-sm">No recent actions!</span>
+          <span className="text-muted-foreground text-sm">Do something to show it here.</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[repo]/_components/repo-contents.tsx
+++ b/src/app/(app)/[repo]/_components/repo-contents.tsx
@@ -1,0 +1,57 @@
+import { Avatar, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Input, InputIcon, InputRoot } from '@/components/ui/input';
+import { Folder, Plus, Search } from 'lucide-react';
+
+export default function RepoContents({ repo }: { repo: string }) {
+  return (
+    <div className="col-span-2 flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <Avatar className="size-5">
+            <AvatarImage src={'https://github.com/moonlitgrace.png'} />
+          </Avatar>
+          <span className="text-muted-foreground/50 text-xl">/</span>
+          <Button variant={'ghost'} className="font-bold" asChild>
+            <a
+              href={`https://github.com/moonlitgrace/${repo}`}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {repo}
+            </a>
+          </Button>
+        </div>
+        <div className="flex flex-1 items-center gap-4">
+          <InputRoot>
+            <InputIcon>
+              <Search />
+            </InputIcon>
+            <Input placeholder="Search..." disabled />
+          </InputRoot>
+          <Button size={'default'}>
+            <Plus />
+            Add New
+          </Button>
+        </div>
+      </div>
+      <div className="mt-2 divide-y overflow-hidden rounded-md border">
+        <div className="hover:bg-secondary/50 grid grid-cols-5 gap-2 p-3">
+          <div className="col-span-2 flex items-center gap-2">
+            <Folder className="fill-muted-foreground text-muted-foreground size-4" />
+            <button className="text-sm hover:underline">.gitloom</button>
+          </div>
+          <a
+            href="https://github.com/GitloomLabs/Gitloom/commit/ca72cffb748c9e9be0a5db83604ebbe81506946f"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-muted-foreground col-span-2 text-sm hover:underline"
+          >
+            chore: update .gitloom settings
+          </a>
+          <span className="text-muted-foreground ml-auto text-sm">2 hours ago</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[repo]/client-page.tsx
+++ b/src/app/(app)/[repo]/client-page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import LoadingRepo from './_components/loading-repo';
+import RecentActions from './_components/recent-actions';
+import RepoContents from './_components/repo-contents';
+
+export default function ClientPage({ repo }: { repo: string }) {
+  const isLoading = true;
+
+  if (isLoading) {
+    return <LoadingRepo repo={repo} />;
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-4 pt-4">
+      <RecentActions />
+      <RepoContents repo={repo} />
+    </div>
+  );
+}

--- a/src/app/(app)/[repo]/page.tsx
+++ b/src/app/(app)/[repo]/page.tsx
@@ -1,10 +1,7 @@
-import { Avatar, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
-import { Input, InputIcon, InputRoot } from '@/components/ui/input';
 import { generateMetadataTitleFor } from '@/lib/utils';
-import { Folder, NavigationOff, Plus, Search } from 'lucide-react';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import ClientPage from './client-page';
 
 interface Props {
   params: Promise<{ repo: string }>;
@@ -29,71 +26,6 @@ export default async function Page({ params }: Props) {
     notFound();
   }
 
-  return (
-    <div className="grid grid-cols-3 gap-4 pt-4">
-      <div className="col-span-1">
-        <h5 className="text-muted-foreground text-sm font-medium">Recent Actions</h5>
-        <div className="flex flex-col items-center justify-center gap-4 py-10">
-          <NavigationOff className="text-muted-foreground size-10 stroke-1" />
-          <div className="flex flex-col items-center">
-            <span className="text-sm">No recent actions!</span>
-            <span className="text-muted-foreground text-sm">Do something to show it here.</span>
-          </div>
-        </div>
-      </div>
-      <div className="col-span-2 flex flex-col gap-2">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <Avatar className="size-5">
-              <AvatarImage src={'https://github.com/moonlitgrace.png'} />
-            </Avatar>
-            <Button variant={'ghost'} className="text-muted-foreground" asChild>
-              <a href="https://github.com/moonlitgrace" target="_blank" rel="noreferrer noopener">
-                moonlitgrace
-              </a>
-            </Button>
-            <span className="text-muted-foreground/50 text-xl">/</span>
-            <Button variant={'ghost'} className="font-bold" asChild>
-              <a
-                href="https://github.com/moonlitgrace/gitloom-repo"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                gitloom-repo
-              </a>
-            </Button>
-          </div>
-          <div className="flex flex-1 items-center gap-4">
-            <InputRoot>
-              <InputIcon>
-                <Search />
-              </InputIcon>
-              <Input placeholder="Search..." disabled />
-            </InputRoot>
-            <Button size={'default'}>
-              <Plus />
-              Add New
-            </Button>
-          </div>
-        </div>
-        <div className="mt-2 divide-y overflow-hidden rounded-md border">
-          <div className="hover:bg-secondary/50 grid grid-cols-5 gap-2 p-3">
-            <div className="col-span-2 flex items-center gap-2">
-              <Folder className="fill-muted-foreground text-muted-foreground size-4" />
-              <button className="text-sm hover:underline">.gitloom</button>
-            </div>
-            <a
-              href="https://github.com/GitloomLabs/Gitloom/commit/ca72cffb748c9e9be0a5db83604ebbe81506946f"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="text-muted-foreground col-span-2 text-sm hover:underline"
-            >
-              chore: update .gitloom settings
-            </a>
-            <span className="text-muted-foreground ml-auto text-sm">2 hours ago</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  // render client-side page
+  return <ClientPage repo={repo} />;
 }

--- a/src/app/(app)/_components/header/header.tsx
+++ b/src/app/(app)/_components/header/header.tsx
@@ -6,12 +6,13 @@ import { Button } from '@/components/ui/button';
 import { ChevronsUpDown } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import UserDropdown from './user-dropdown';
 
 export default function Header() {
   const { data: session } = useSession();
   const pathname = usePathname();
+  const { repo } = useParams<{ repo: string }>();
   const isNewPath = pathname === '/new';
 
   return (
@@ -27,7 +28,7 @@ export default function Header() {
               <Avatar className="size-5">
                 <AvatarImage src={session?.user?.image ?? undefined} />
               </Avatar>
-              <span className="text-sm font-bold">gitloom-repo</span>
+              <span className="text-sm font-bold">{decodeURIComponent(repo)}</span>
               <ChevronsUpDown className="opacity-50" />
             </Button>
           </>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -9,7 +9,7 @@ export default function AppLayout({
   return (
     <main>
       <Header />
-      <div className="mx-auto min-h-[calc(100dvh-3.75rem)] max-w-300 px-5 lg:px-0">{children}</div>
+      <div className="mx-auto h-[calc(100dvh-3.75rem)] max-w-300 px-5 lg:px-0">{children}</div>
       <Footer />
     </main>
   );

--- a/src/app/(app)/new/_components/repo-list-skeleton.tsx
+++ b/src/app/(app)/new/_components/repo-list-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function RepoListSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, idx) => {
+        const minRem = 10;
+        const maxRem = 15;
+        const randomRem = minRem + ((idx * 2) % (maxRem - minRem + 1));
+
+        return (
+          <div key={idx} className="flex h-14 items-center gap-2 px-3">
+            <Skeleton className="size-5 rounded-full" />
+            <Skeleton className="h-5" style={{ width: `${randomRem}rem` }} />
+            <Skeleton className="ml-auto h-8 w-17" />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/app/(app)/new/_components/repo-list-skeleton.tsx
+++ b/src/app/(app)/new/_components/repo-list-skeleton.tsx
@@ -1,9 +1,9 @@
 import { Skeleton } from '@/components/ui/skeleton';
 
-export function RepoListSkeleton({ count = 5 }: { count?: number }) {
+export function RepoListSkeleton() {
   return (
     <>
-      {Array.from({ length: count }).map((_, idx) => {
+      {Array.from({ length: 5 }).map((_, idx) => {
         const minRem = 10;
         const maxRem = 15;
         const randomRem = minRem + ((idx * 2) % (maxRem - minRem + 1));

--- a/src/app/(app)/new/_components/repo-list.tsx
+++ b/src/app/(app)/new/_components/repo-list.tsx
@@ -74,7 +74,7 @@ export default function RepoList() {
             <span className="text-muted-foreground text-sm">
               {datetime(repo.updated_at).fromNow()}
             </span>
-            <Button className="ml-auto" onClick={() => router.push(`/@${repo.name}?import=true`)}>
+            <Button className="ml-auto" onClick={() => router.push(`/@${repo.name}`)}>
               Import
             </Button>
           </div>

--- a/src/app/(app)/new/_components/repo-list.tsx
+++ b/src/app/(app)/new/_components/repo-list.tsx
@@ -12,67 +12,38 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
-import useDebounce from '@/hooks/use-debounce';
+import useRepos from '@/hooks/use-repos';
+import { importRepo } from '@/lib/api/github';
 import datetime from '@/lib/date-time';
-import { useQuery } from '@tanstack/react-query';
 import { Lock, Search } from 'lucide-react';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
-
-interface Repo {
-  id: number;
-  name: string;
-  private: boolean;
-  updated_at: string;
-  html_url: string;
-}
-
-async function fetchRepos({
-  accessToken,
-  username,
-  query,
-}: {
-  accessToken: string;
-  username: string;
-  query: string;
-}): Promise<Repo[]> {
-  const url = `https://api.github.com/search/repositories?q=${query}+user:${username}&sort=updated&per_page=5`;
-
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  const data = await res.json();
-  return data.items.map((repo: Repo) => ({
-    id: repo.id,
-    name: repo.name,
-    private: repo.private,
-    updated_at: repo.updated_at,
-    html_url: repo.html_url,
-  }));
-}
+import { RepoListSkeleton } from './repo-list-skeleton';
 
 export default function RepoList() {
   const { data: session, status } = useSession();
+  const { search, setSearch, debouncedSearch, repos, isLoading } = useRepos();
+  const [isImporting, setIsImporting] = useState(false);
+
   const accessToken = session?.accessToken;
   const username = session?.user?.username;
 
-  const [search, setSearch] = useState('');
-  const debouncedSearch = useDebounce(search, 500);
+  async function handleImport(repoName: string) {
+    try {
+      setIsImporting(true);
+      if (!session) return;
 
-  const { data: repos, isLoading } = useQuery({
-    queryKey: ['repos', username, debouncedSearch],
-    queryFn: () =>
-      fetchRepos({
-        accessToken: accessToken!,
-        username: username!,
-        query: debouncedSearch,
-      }),
-    // only fetch if there is valid session
-    enabled: !!accessToken && !!username,
-  });
+      const data = await importRepo({
+        accessToken,
+        username,
+        repo: repoName,
+      });
+
+      console.log(data);
+    } finally {
+      setIsImporting(false);
+    }
+  }
 
   return (
     <>
@@ -89,7 +60,6 @@ export default function RepoList() {
             </SelectContent>
           </Select>
         )}
-
         <InputRoot>
           <InputIcon>
             {debouncedSearch.length > 0 && isLoading ? (
@@ -106,20 +76,7 @@ export default function RepoList() {
         </InputRoot>
       </div>
       <div className="divide-y rounded-md border">
-        {(status === 'loading' || isLoading) &&
-          Array.from({ length: 5 }).map((_, idx) => {
-            const minRem = 10;
-            const maxRem = 15;
-            const randomRem = minRem + ((idx * 2) % (maxRem - minRem + 1));
-
-            return (
-              <div key={idx} className="flex h-14 items-center gap-2 px-3">
-                <Skeleton className="size-5 rounded-full" />
-                <Skeleton className="h-5" style={{ width: `${randomRem}rem` }} />
-                <Skeleton className="ml-auto h-8 w-17" />
-              </div>
-            );
-          })}
+        {(status === 'loading' || isLoading) && <RepoListSkeleton />}
         {repos?.map((repo) => (
           <div key={repo.id} className="flex h-14 items-center gap-2 px-3">
             <GithubIcon className="fill-muted-foreground size-5" />
@@ -135,7 +92,13 @@ export default function RepoList() {
             <span className="text-muted-foreground text-sm">
               {datetime(repo.updated_at).fromNow()}
             </span>
-            <Button className="ml-auto">Import</Button>
+            <Button
+              className="ml-auto"
+              onClick={() => handleImport(repo.name)}
+              disabled={isImporting}
+            >
+              Import
+            </Button>
           </div>
         ))}
       </div>

--- a/src/app/(app)/new/_components/repo-list.tsx
+++ b/src/app/(app)/new/_components/repo-list.tsx
@@ -13,37 +13,19 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
 import useRepos from '@/hooks/use-repos';
-import { importRepo } from '@/lib/api/github';
 import datetime from '@/lib/date-time';
 import { Lock, Search } from 'lucide-react';
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { RepoListSkeleton } from './repo-list-skeleton';
 
 export default function RepoList() {
+  const router = useRouter();
   const { data: session, status } = useSession();
   const { search, setSearch, debouncedSearch, repos, isLoading } = useRepos();
-  const [isImporting, setIsImporting] = useState(false);
 
-  const accessToken = session?.accessToken;
+  // easy access
   const username = session?.user?.username;
-
-  async function handleImport(repoName: string) {
-    try {
-      setIsImporting(true);
-      if (!session) return;
-
-      const data = await importRepo({
-        accessToken,
-        username,
-        repo: repoName,
-      });
-
-      console.log(data);
-    } finally {
-      setIsImporting(false);
-    }
-  }
 
   return (
     <>
@@ -92,11 +74,7 @@ export default function RepoList() {
             <span className="text-muted-foreground text-sm">
               {datetime(repo.updated_at).fromNow()}
             </span>
-            <Button
-              className="ml-auto"
-              onClick={() => handleImport(repo.name)}
-              disabled={isImporting}
-            >
+            <Button className="ml-auto" onClick={() => router.push(`/@${repo.name}?import=true`)}>
               Import
             </Button>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from '@/components/ui/sonner';
 import QueryProvider from '@/providers/query-provider';
 import type { Metadata } from 'next';
 import { SessionProvider } from 'next-auth/react';
@@ -20,6 +21,7 @@ export default function RootLayout({
         <SessionProvider>
           <QueryProvider>{children}</QueryProvider>
         </SessionProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import * as React from 'react';
+
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner, ToasterProps } from 'sonner';
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,8 @@
 export const LOCAL_STORAGE_KEYS = {
   LAST_USED_REPO: 'gitloom:last-used-repo',
 } as const;
+
+export const DEFAULT_CONFIG = {
+  version: '1.0.0',
+  contents: [],
+};

--- a/src/hooks/use-repos.ts
+++ b/src/hooks/use-repos.ts
@@ -1,0 +1,29 @@
+import { fetchRepos } from '@/lib/api/github';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+import useDebounce from './use-debounce';
+
+export default function useRepos() {
+  const { data: session } = useSession();
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 500);
+
+  const accessToken = session?.accessToken;
+  const username = session?.user?.username;
+
+  const { data: repos, isLoading } = useQuery({
+    queryKey: ['repos', username, debouncedSearch],
+    queryFn: () => fetchRepos({ accessToken, username, query: debouncedSearch }),
+    // only fetch if there is valid session
+    enabled: !!session,
+  });
+
+  return {
+    search,
+    setSearch,
+    debouncedSearch,
+    repos,
+    isLoading,
+  };
+}

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -22,6 +22,22 @@ export async function fetchRepos({
   }));
 }
 
+export async function checkRepo({
+  accessToken,
+  username,
+  repo,
+}: ImportRepoParams): Promise<boolean> {
+  const url = `https://api.github.com/repos/${username}/${repo}`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return res.ok;
+}
+
 export async function importRepo({
   accessToken,
   username,

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -38,7 +38,7 @@ export async function checkRepo({
   return res.ok;
 }
 
-export async function importRepo({
+export async function importRepoConfig({
   accessToken,
   username,
   repo,
@@ -58,6 +58,5 @@ export async function importRepo({
   }
 
   const data = await res.json();
-  console.log(data);
   return data;
 }

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -1,0 +1,47 @@
+import { FetchReposParams, ImportRepoParams, Repo } from '@/types/github';
+
+export async function fetchRepos({
+  accessToken,
+  username,
+  query,
+}: FetchReposParams): Promise<Repo[]> {
+  const url = `https://api.github.com/search/repositories?q=${query}+user:${username}&sort=updated&per_page=5`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return data.items.map((repo: Repo) => ({
+    id: repo.id,
+    name: repo.name,
+    private: repo.private,
+    updated_at: repo.updated_at,
+    html_url: repo.html_url,
+  }));
+}
+
+export async function importRepo({
+  accessToken,
+  username,
+  repo,
+}: ImportRepoParams): Promise<unknown | null> {
+  const url = `https://api.github.com/repos/${username}/${repo}/contents/.gitloom/config.json`;
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'pplication/vnd.github+json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok && res.status === 404) {
+    // there is no config file
+    console.log('.gitloom/config.json not found.');
+    return null;
+  }
+
+  const data = await res.json();
+  console.log(data);
+  return data;
+}

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -14,6 +14,15 @@ export interface FetchReposParams {
   query: string;
 }
 
-export interface ImportRepoParams extends Omit<FetchReposParams, 'query'> {
+export interface CheckRepoParams extends Omit<FetchReposParams, 'query'> {
   repo: Repo['name'];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ImportRepoConfigParams extends CheckRepoParams {}
+
+export interface CreateContentParams extends ImportRepoConfigParams {
+  path: string;
+  message: string;
+  content: unknown;
 }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,19 @@
+export interface Repo {
+  id: number;
+  name: string;
+  private: boolean;
+  updated_at: string;
+  html_url: string;
+}
+
+// ===== function params ======
+
+export interface FetchReposParams {
+  accessToken: string | undefined;
+  username: string | undefined;
+  query: string;
+}
+
+export interface ImportRepoParams extends Omit<FetchReposParams, 'query'> {
+  repo: Repo['name'];
+}


### PR DESCRIPTION
When user imports a repo, redirects to `/@[repo]` page.
First, it shows loading page of repo, where it checks the status, config files, etc... of the repo and also shows alert dialog to create a default `.gitloom/config.json` file in the repo.

preview:
![image](https://github.com/user-attachments/assets/45333e9d-2a67-493c-9456-f06020413f1a)
